### PR TITLE
Changes to allow subclassing

### DIFF
--- a/src/main/actionscript/eu/alebianco/robotlegs/utils/impl/AbstractMacro.as
+++ b/src/main/actionscript/eu/alebianco/robotlegs/utils/impl/AbstractMacro.as
@@ -17,7 +17,7 @@ import robotlegs.bender.framework.api.IInjector;
 import robotlegs.bender.framework.impl.applyHooks;
 import robotlegs.bender.framework.impl.guardsApprove;
 
-internal class AbstractMacro extends AsyncCommand implements IMacro {
+public class AbstractMacro extends AsyncCommand implements IMacro {
 
     [Inject]
     public var injector:IInjector;

--- a/src/main/actionscript/eu/alebianco/robotlegs/utils/impl/ParallelMacro.as
+++ b/src/main/actionscript/eu/alebianco/robotlegs/utils/impl/ParallelMacro.as
@@ -13,12 +13,12 @@ import eu.alebianco.robotlegs.utils.api.ISubCommandMapping;
 
 public class ParallelMacro extends AbstractMacro implements IMacro {
 
-    private var executionCount:uint = 0;
+    protected var executionCount:uint = 0;
 
-    private var commands:Vector.<ISubCommandMapping>;
+    protected var commands:Vector.<ISubCommandMapping>;
 
-    private var success:Boolean = true;
-    private var running:Boolean = false;
+    protected var success:Boolean = true;
+    protected var running:Boolean = false;
 
     override public function execute():void {
         super.execute();
@@ -34,7 +34,7 @@ public class ParallelMacro extends AbstractMacro implements IMacro {
         }
     }
 
-    private function get hasCommands():Boolean {
+    protected function get hasCommands():Boolean {
         return mappings && commands.length > 0;
     }
 

--- a/src/main/actionscript/eu/alebianco/robotlegs/utils/impl/SequenceMacro.as
+++ b/src/main/actionscript/eu/alebianco/robotlegs/utils/impl/SequenceMacro.as
@@ -13,12 +13,12 @@ import eu.alebianco.robotlegs.utils.api.ISubCommandMapping;
 
 public class SequenceMacro extends AbstractMacro implements IMacro {
 
-    private var executionIndex:uint;
+    protected var executionIndex:uint;
 
-    private var success:Boolean = true;
-    private var running:Boolean = false;
+    protected var success:Boolean = true;
+    protected var running:Boolean = false;
 
-    private var commands:Vector.<ISubCommandMapping>;
+    protected var commands:Vector.<ISubCommandMapping>;
 
     private var _atomic:Boolean = true;
     public function get atomic():Boolean {
@@ -48,7 +48,7 @@ public class SequenceMacro extends AbstractMacro implements IMacro {
         }
     }
 
-    private function get hasCommands():Boolean {
+    protected function get hasCommands():Boolean {
         return commands && executionIndex < commands.length;
     }
 


### PR DESCRIPTION
Hi,

Thanks for macrobot. I have been using it for a long time now!

I think it's a good idea to allow subclassing of these great commands. For example, I would like to create a SequenceMacro that is able to dispatch its progress while processing the sequence. I have also created an InterruptableSequenceMacro, that runs as an interruptable singleton command, allowing the command to be cancelled or restarted with new data. This has required that I make the properties of SequenceMacro protected for access and overriding. It therefore made sense to do the same for ParallelMacro, and AbstractMacro.
